### PR TITLE
chore: allow renovate to bump to node 20 for development

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,19 @@
 		{
 			"packageNames": ["@types/node", "node"],
 			"allowedVersions": "^20.0.0",
-			"major": { "enabled": true }
+			"major": {
+				"enabled": true,
+				"semanticCommitType": "fix"
+			}
+		},
+		{
+			"matchPackageNames": ["typescript"],
+			"major": {
+				"semanticCommitType": "fix"
+			},
+			"minor": {
+				"semanticCommitType": "fix"
+			}
 		},
 		{
 			"matchPackageNames": ["@microsoft/api-documenter", "@microsoft/api-extractor"],

--- a/renovate.json
+++ b/renovate.json
@@ -12,8 +12,8 @@
 	"ignorePaths": ["**/examples/**"],
 	"packageRules": [
 		{
-			"packageNames": ["@types/node"],
-			"allowedVersions": "^18.0.0",
+			"packageNames": ["@types/node", "node"],
+			"allowedVersions": "^20.0.0",
 			"major": { "enabled": true }
 		},
 		{


### PR DESCRIPTION
A couple updates for renovate to update it to deal with some expectations a little nicer