### PR TITLE
fix: duplicate type information with cjs extension for typescript

### DIFF
--- a/.changeset/afraid-squids-film.md
+++ b/.changeset/afraid-squids-film.md
@@ -1,0 +1,5 @@
+---
+'@mscharley/dot': patch
+---
+
+Fix CommonJS imports in node16 resolution mode

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,14 @@ tsdoc-metadata.json
 .stryker-tmp
 
 # Final built files
+## ESM build
 /dot.js
 /dot.js.map
-/dot.cjs
-/dot.cjs.map
 /dot.d.ts
 /dot.v4.d.ts
+
+## CJS build
+/dot.cjs
+/dot.cjs.map
+/dot.d.cts
+/dot.v4.d.cts

--- a/examples/ts4-cjs/package-lock.json
+++ b/examples/ts4-cjs/package-lock.json
@@ -16,12 +16,14 @@
 			}
 		},
 		"../..": {
-			"version": "1.4.2",
+			"name": "@mscharley/dot",
+			"version": "1.4.8",
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "*"
 			},
 			"devDependencies": {
+				"@changesets/cli": "2.26.2",
 				"@jest/globals": "29.7.0",
 				"@microsoft/api-documenter": "7.23.9",
 				"@microsoft/api-extractor": "7.38.0",

--- a/examples/ts4-cjs/tsconfig.json
+++ b/examples/ts4-cjs/tsconfig.json
@@ -25,8 +25,8 @@
 		// "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
 		/* Modules */
-		"module": "CommonJS" /* Specify what module code is generated. */,
-		"moduleResolution": "Node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+		"module": "Node16" /* Specify what module code is generated. */,
+		"moduleResolution": "Node16" /* Specify how TypeScript looks up a file from a given module specifier. */,
 		// "rootDir": "./",                                  /* Specify the root folder within your source files. */
 		// "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
 		// "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
 	"exports": {
 		".": {
 			"require": {
-				"types@<5.0": "./dot.v4.d.ts",
-				"types": "./dot.d.ts",
+				"types@<5.0": "./dot.v4.d.cts",
+				"types": "./dot.d.cts",
 				"default": "./dot.cjs"
 			},
 			"import": {
@@ -43,7 +43,7 @@
 		"prepack": "npm run clean && npm run build",
 		"build": "npm run build:tsc && npm run build:api && npm run build:esbuild",
 		"build:tsc": "tsc",
-		"build:api": "api-extractor run --local && grep -v 'DecoratorContext' dot.d.ts > dot.v4.d.ts",
+		"build:api": "api-extractor run --local && grep -v 'DecoratorContext' dot.d.ts > dot.v4.d.ts && cp dot.d.ts dot.d.cts && cp dot.v4.d.ts dot.v4.d.cts",
 		"build:docs": "api-documenter markdown -i ./reports/docs -o ./docs",
 		"build:esbuild": "npm run build:esbuild:esm && npm run build:esbuild:cjs",
 		"build:esbuild:cjs": "esbuild dist/index.js --bundle --sourcemap=linked --outfile=dot.cjs --platform=node --packages=external",


### PR DESCRIPTION
TypeScript insists that types for `exports` which apply to CJS files in an ESM library and vice versa must have the correct file extension even if they are explicitly set in `package.json` to be the other kind of file. TypeScript will just act like the file doesn't exist.