### PR TITLE
fix: another bug with mixed esm/cjs environments

### DIFF
--- a/.changeset/fifty-wombats-tan.md
+++ b/.changeset/fifty-wombats-tan.md
@@ -1,0 +1,5 @@
+---
+'@mscharley/dot': patch
+---
+
+Fix an issue with tokens in mixed CJS/ESM environments

--- a/etc/dot.api.md
+++ b/etc/dot.api.md
@@ -294,6 +294,8 @@ type SyncContainerModule = (bind: BindFunction, unbind: UnbindFunction, isBound:
 export class Token<out T> {
     constructor(name: string);
     readonly identifier: symbol;
+    // (undocumented)
+    get _witness(): T;
 }
 
 // @public
@@ -303,7 +305,11 @@ export class TokenResolutionError extends ResolutionError {
 }
 
 // @public
-export type TokenType<T extends Token<unknown>> = T extends Token<infer U> ? U : never;
+export type TokenType<T extends {
+    _witness: unknown;
+}> = T extends {
+    _witness: infer U;
+} ? U : never;
 
 // @public
 type UnbindFunction = <T>(id: ServiceIdentifier<T>) => void;

--- a/etc/dot.api.md
+++ b/etc/dot.api.md
@@ -293,8 +293,8 @@ type SyncContainerModule = (bind: BindFunction, unbind: UnbindFunction, isBound:
 // @public
 export class Token<out T> {
     constructor(name: string);
+    // @internal
     readonly identifier: symbol;
-    // (undocumented)
     get _witness(): T;
 }
 

--- a/src/Token.ts
+++ b/src/Token.ts
@@ -11,7 +11,9 @@
  *
  * @public
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
+import { InvalidOperationError } from './Error.js';
+
 export class Token<out T> {
 	/**
 	 * The Symbol used as the unique identifier for this token
@@ -21,6 +23,10 @@ export class Token<out T> {
 	public constructor(name: string) {
 		this.identifier = Symbol(name);
 	}
+
+	public get _witness(): T {
+		throw new InvalidOperationError("Don't access the token witness, this isn't a real variable");
+	}
 }
 
 /**
@@ -28,4 +34,4 @@ export class Token<out T> {
  *
  * @public
  */
-export type TokenType<T extends Token<unknown>> = T extends Token<infer U> ? U : never;
+export type TokenType<T extends { _witness: unknown }> = T extends { _witness: infer U } ? U : never;

--- a/src/Token.ts
+++ b/src/Token.ts
@@ -17,6 +17,8 @@ import { InvalidOperationError } from './Error.js';
 export class Token<out T> {
 	/**
 	 * The Symbol used as the unique identifier for this token
+	 *
+	 * @internal
 	 */
 	public readonly identifier: symbol;
 
@@ -24,6 +26,14 @@ export class Token<out T> {
 		this.identifier = Symbol(name);
 	}
 
+	/**
+	 * This is a dummy variable, it throws an error on access
+	 *
+	 * @remarks
+	 *
+	 * This property mainly exists to facilitate some compatibility across ESM and CommonJS in mixed environments. It is
+	 * only here for the extra type information and accessing the value of this property is an error.
+	 */
 	public get _witness(): T {
 		throw new InvalidOperationError("Don't access the token witness, this isn't a real variable");
 	}


### PR DESCRIPTION
There's a similar issue in `InjectedType` but it doesn't seem to be affecting the usecase I have at the moment so hopefully it's only a theoretical issue and not a practical one.