### PR TITLE
fix: instanceof is unreliable for classes in this library

### DIFF
--- a/.changeset/big-fireants-knock.md
+++ b/.changeset/big-fireants-knock.md
@@ -1,0 +1,5 @@
+---
+'@mscharley/dot': patch
+---
+
+instanceof is unreliable in mixed cjs/esm environments

--- a/src/util/injectionFromIdentifier.ts
+++ b/src/util/injectionFromIdentifier.ts
@@ -1,11 +1,10 @@
 import type * as interfaces from '../interfaces/index.js';
 import type { Injection } from '../models/Injection.js';
-import { Token } from '../Token.js';
 
 export const injectionFromIdentifier = <T>(id: interfaces.InjectionIdentifier<T>, index: number): Injection<T> => {
 	const token = Array.isArray(id) ? id[0] : id;
 	const partialOpts = Array.isArray(id) ? id[1] : {};
-	if (typeof token === 'function' || token instanceof Token) {
+	if (typeof token === 'function' || 'identifier' in token) {
 		return {
 			type: 'constructorParameter',
 			index,

--- a/src/util/stringifyIdentifier.ts
+++ b/src/util/stringifyIdentifier.ts
@@ -1,5 +1,4 @@
 import type * as interfaces from '../interfaces/index.js';
-import { Token } from '../Token.js';
 
 /**
  * Turn a service identifier into a string
@@ -7,7 +6,7 @@ import { Token } from '../Token.js';
  * @public
  */
 export const stringifyIdentifier = <T>(id: interfaces.ServiceIdentifier<T>): string => {
-	if (id instanceof Token) {
+	if ('identifier' in id) {
 		return `Token<${id.identifier.toString()}>`;
 	} else {
 		// Stryker disable all: Stryker only tests TC39, but this construct operates differently on experimental

--- a/src/util/tokenForIdentifier.ts
+++ b/src/util/tokenForIdentifier.ts
@@ -6,7 +6,7 @@ const mappingsCache = Symbol.for('@mscharley/dot:identifier-token-mappings');
 const _mappings: WeakMap<interfaces.Constructor<unknown>, Token<unknown>> = makeGlobalCache(mappingsCache);
 
 export const tokenForIdentifier = <T>(id: interfaces.ServiceIdentifier<T>): Token<T> => {
-	if (id instanceof Token) {
+	if ('identifier' in id) {
 		return id;
 	} else {
 		if (!_mappings.has(id)) {


### PR DESCRIPTION
Don't use `instanceof` with classes exported from this library as it's possible there is two copies of the class, one ESM version and one CJS version which are incompatible with each other. Duck typing is the solution here.