### PR TITLE
fix: allow autobound classes to be cached

### DIFF
--- a/.changeset/wild-eggs-walk.md
+++ b/.changeset/wild-eggs-walk.md
@@ -1,0 +1,5 @@
+---
+'@mscharley/dot': patch
+---
+
+Fix a bug around how autobound classes are scoped

--- a/src/__tests__/Autobinding.ts
+++ b/src/__tests__/Autobinding.ts
@@ -37,4 +37,15 @@ describe('Autobinding', () => {
 		const child = c.createChild({ autobindClasses: true });
 		await expect(child.get(Greeter)).resolves.toMatchObject({ greeting: 'Hello, John!' });
 	});
+
+	it('respects the default scope of a container', async () => {
+		const container = new Container({ autobindClasses: true, defaultScope: 'singleton' });
+
+		@injectable()
+		class Test {
+			public id = 10;
+		}
+
+		expect(await container.get(Test)).toBe(await container.get(Test));
+	});
 });

--- a/src/container/Container.ts
+++ b/src/container/Container.ts
@@ -134,15 +134,18 @@ export class Container implements interfaces.Container {
 		}
 
 		if (this.config.autobindClasses && typeof id === 'function' && !(this.config.parent?.has(id) ?? false)) {
-			return [
-				{
-					type: 'constructor',
-					ctr: id,
-					id,
-					token: tokenForIdentifier(id),
-					scope: this.config.defaultScope,
-				} satisfies ConstructorBinding<T>,
-			];
+			const binding = {
+				type: 'constructor',
+				ctr: id,
+				id,
+				token,
+				scope: this.config.defaultScope,
+			} satisfies ConstructorBinding<T>;
+
+			// Save this binding to make sure that caches work for future attempts to get this class.
+			this.#bindings.push(binding);
+
+			return [binding];
 		}
 
 		return [];


### PR DESCRIPTION
Make sure to save any autobindings that are created so that we use a consistent binding for them and can cache those bindings.

Fixes #184 