### PR TITLE
fix: a race condition with concurrent requests to the container

### DIFF
--- a/.changeset/new-dragons-notice.md
+++ b/.changeset/new-dragons-notice.md
@@ -1,0 +1,5 @@
+---
+'@mscharley/dot': patch
+---
+
+Fix a race condition with caching and concurrent requests to the container

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.6.0",
 			"license": "MIT",
 			"dependencies": {
+				"async-mutex": "^0.5.0",
 				"tslib": "*"
 			},
 			"devDependencies": {
@@ -5275,6 +5276,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/async-mutex": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+			"integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/autoprefixer": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"url": "https://github.com/sponsors/mscharley"
 	},
 	"dependencies": {
+		"async-mutex": "^0.5.0",
 		"tslib": "*"
 	},
 	"devDependencies": {

--- a/src/__tests__/AsyncTests.ts
+++ b/src/__tests__/AsyncTests.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { Container } from '../container/Container.js';
+import { injectable } from '../decorators/injectable.js';
+
+@injectable()
+class Name {
+	public name = 'World';
+}
+
+@injectable(Name)
+class Greeter {
+	public readonly greeting: string;
+
+	public constructor({ name }: Name) {
+		this.greeting = `Hello, ${name}!`;
+	}
+}
+
+describe('async tests', () => {
+	it('works correctly with caches', async () => {
+		const c = new Container({ autobindClasses: true, defaultScope: 'singleton' });
+
+		const [g1, g2] = await Promise.all([c.get(Greeter), c.get(Greeter)]);
+		expect(g1).toBe(g2);
+	});
+
+	it('releases correctly if errors occur', async () => {
+		const c = new Container({ autobindClasses: true, defaultScope: 'singleton' });
+		const factory = jest.fn<() => Greeter>();
+		c.bind(Greeter).toDynamicValue([], factory);
+
+		factory.mockImplementationOnce(() => {
+			throw new Error('Oops!');
+		});
+		await expect(c.get(Greeter)).rejects.toThrow('Encountered an error while creating a class');
+
+		factory.mockImplementationOnce(() => new Greeter(new Name()));
+		const g2 = await c.get(Greeter);
+		expect(g2).toBeInstanceOf(Greeter);
+	});
+});

--- a/src/planner/executePlan.ts
+++ b/src/planner/executePlan.ts
@@ -1,69 +1,97 @@
+import type * as interfaces from '../interfaces/index.js';
 import { InvalidOperationError, TokenResolutionError } from '../Error.js';
+import type { Binding } from '../models/Binding.js';
 import { isNever } from '../util/isNever.js';
+import type { MutexInterface } from 'async-mutex';
 import type { Plan } from '../models/Plan.js';
 import type { Request } from '../models/Request.js';
 import { ResolutionCache } from '../container/ResolutionCache.js';
 import { stringifyIdentifier } from '../util/stringifyIdentifier.js';
 
-export const executePlan = async <T>(plan: Plan, { singletonCache, stack, token }: Request<T>): Promise<T> => {
+export const executePlan = async <T>(plan: Plan, { container, singletonCache, stack, token }: Request<T>): Promise<T> => {
 	const caches: Record<'singleton' | 'request', ResolutionCache> = {
 		singleton: singletonCache,
 		request: new ResolutionCache(),
 	};
+	const releases = new Map<Binding<unknown, interfaces.MetadataObject>, MutexInterface.Releaser>();
 
-	let skip = 0;
-	for (const step of plan) {
-		if (skip > 0) {
-			skip--;
-			continue;
-		}
+	try {
+		let skip = 0;
+		for (const step of plan) {
+			if (skip > 0) {
+				skip--;
+				continue;
+			}
 
-		const stepStack = stack[step.token.identifier] ?? [];
-		switch (step.type) {
-			case 'fetchFromCache':
-				if (caches[step.cache].has(step.binding)) {
-					stepStack.push(caches[step.cache].get(step.binding));
-					skip = step.skipStepsIfFound;
-				}
-				break;
-			case 'createClass': {
-				try {
+			const stepStack = stack[step.token.identifier] ?? [];
+			switch (step.type) {
+				case 'fetchFromCache': {
 					// eslint-disable-next-line no-await-in-loop
-					const value = await step.generate();
-					stepStack.push(value);
-					if (step.cache != null && step.binding != null) {
-						caches[step.cache].set(step.binding, value);
+					const releaser = await caches[step.cache].lock(step.binding);
+					releases.set(step.binding, releaser);
+					if (caches[step.cache].has(step.binding)) {
+						stepStack.push(caches[step.cache].get(step.binding));
+						skip = step.skipStepsIfFound;
+						releaser();
+						releases.delete(step.binding);
 					}
-				} catch (err: unknown) {
-					throw new TokenResolutionError(
-						'Encountered an error while creating a class',
-						step.resolutionPath,
-						err instanceof Error ? err : new Error(`${err}`),
-					);
+					break;
 				}
-				break;
-			}
-			case 'aggregateMultiple': {
-				const value = stepStack.splice(-step.count);
-				if (value.length !== step.count) {
-					throw new TokenResolutionError(
-						'Unable to load injected services',
-						step.resolutionPath,
-						new InvalidOperationError(`Unexpected number of services: ${value.length} !== ${step.count}`),
-					);
+				case 'createClass': {
+					try {
+						// eslint-disable-next-line no-await-in-loop
+						const value = await step.generate();
+						stepStack.push(value);
+						if (step.cache != null && step.binding != null) {
+							caches[step.cache].set(step.binding, value);
+							const releaser = releases.get(step.binding);
+							if (releaser != null) {
+								releaser();
+								releases.delete(step.binding);
+							}
+						}
+					} catch (err: unknown) {
+						throw new TokenResolutionError(
+							'Encountered an error while creating a class',
+							step.resolutionPath,
+							err instanceof Error ? err : new Error(`${err}`),
+						);
+					}
+					break;
 				}
-				stepStack.push(value.flat());
-				break;
-			}
-			case 'requestFromParent':
+				case 'aggregateMultiple': {
+					const value = stepStack.splice(-step.count);
+					if (value.length !== step.count) {
+						throw new TokenResolutionError(
+							'Unable to load injected services',
+							step.resolutionPath,
+							new InvalidOperationError(`Unexpected number of services: ${value.length} !== ${step.count}`),
+						);
+					}
+					stepStack.push(value.flat());
+					break;
+				}
+				case 'requestFromParent':
 				// eslint-disable-next-line no-await-in-loop
-				stepStack.push(await step.parent.get(step.token, step.options));
-				break;
-			default:
-				return isNever(step, 'Invalid plan step');
+					stepStack.push(await step.parent.get(step.token, step.options));
+					break;
+				default:
+					return isNever(step, 'Invalid plan step');
+			}
+			// eslint-disable-next-line require-atomic-updates
+			stack[step.token.identifier] = stepStack;
 		}
-		// eslint-disable-next-line require-atomic-updates
-		stack[step.token.identifier] = stepStack;
+		// No error caused us to fail early, so warn about these issues.
+		for (const [binding, r] of releases.entries()) {
+			container.config.logger.warn({ binding }, 'Releasing unreleased mutex, this is probably a bug in DOT.');
+			r();
+		}
+		releases.clear();
+	}	finally {
+		// If we hit this then we likely ran into an error above, so silently clean up behind ourselves.
+		for (const r of releases.values()) {
+			r();
+		}
 	}
 
 	if (!(token.identifier in stack)) {


### PR DESCRIPTION
Fixes an issue where concurrent requests into the container could bypass the caches and trigger multiple erroneous creations of the same binding.